### PR TITLE
gh token

### DIFF
--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -44,9 +44,9 @@ jobs:
         if: steps.changed-files.outputs.all_changed_files != ''
         id: get-pr-number
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
         run: |
-          # we can't use the gh cli without first setting an environmental variable...
-          export GITHUB_TOKEN="${{ secrets.TEMPLATES_GITHUB_TOKEN }}"
           # we need the pull request number that created the push that triggered this event.
           prNumber=$(gh api "/repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" | jq -r '.[] | .number')
 


### PR DESCRIPTION
[According to the docs,](https://cli.github.com/manual/gh_help_environment) we should be able to have our token set as `GITHUB_TOKEN` but inside a step it's very picky